### PR TITLE
Add random color rendering mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+pytest_cache/
+.pytest_cache/
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# fractal
+# Fractal Generator
+
+This project contains a simple web-based fractal image generator implemented in HTML and JavaScript. It can render Mandelbrot and Julia sets on a canvas element.
+
+## Usage
+
+Open `index.html` in a modern web browser. Select the fractal type, choose **Fractal** or **Random Colors** mode, adjust the iteration count and (for Julia set) a complex constant, then click **Render** to generate the output.
+
+When **Random Colors** mode is selected a new pattern will be drawn each time the page is refreshed.
+
+The rendering runs entirely in the browser.

--- a/README.md
+++ b/README.md
@@ -9,3 +9,12 @@ Open `index.html` in a modern web browser. Select the fractal type, choose **Fra
 When **Random Colors** mode is selected a new pattern will be drawn each time the page is refreshed.
 
 The rendering runs entirely in the browser.
+
+## Development
+
+Run the unit tests with:
+
+```bash
+npm test
+```
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Fractal Generator</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Fractal Generator</h1>
+    <div id="controls">
+        <label for="fractal-type">Fractal type:</label>
+        <select id="fractal-type">
+            <option value="mandelbrot">Mandelbrot</option>
+            <option value="julia">Julia</option>
+        </select>
+        <label for="mode">Mode:</label>
+        <select id="mode">
+            <option value="fractal" selected>Fractal</option>
+            <option value="random">Random Colors</option>
+        </select>
+        <label for="iterations">Iterations:</label>
+        <input type="number" id="iterations" value="100" min="10" max="1000">
+        <label for="julia-c">Julia constant (for Julia set):</label>
+        <input type="text" id="julia-c" value="-0.8+0.156i">
+        <button id="render">Render</button>
+    </div>
+    <canvas id="canvas" width="800" height="600"></canvas>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "fractal",
+  "version": "1.0.0",
+  "description": "This project contains a simple web-based fractal image generator implemented in HTML and JavaScript. It can render Mandelbrot and Julia sets on a canvas element.",
+  "main": "script.js",
+  "scripts": {
+    "test": "node test/script.test.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This project contains a simple web-based fractal image generator implemented in HTML and JavaScript. It can render Mandelbrot and Julia sets on a canvas element.",
   "main": "script.js",
   "scripts": {
-    "test": "node test/script.test.js"
+    "test": "node test/script.test.js && node test/random.test.js"
   },
   "keywords": [],
   "author": "",

--- a/script.js
+++ b/script.js
@@ -1,0 +1,84 @@
+function parseComplex(str) {
+    const match = str.match(/([+-]?\d*\.?\d+)([+-]\d*\.?\d+)i/);
+    if (!match) {
+        return { re: -0.8, im: 0.156 };
+    }
+    return { re: parseFloat(match[1]), im: parseFloat(match[2]) };
+}
+
+function calculateIterations(zx, zy, cx, cy, iterCount) {
+    let i = 0;
+    while (zx * zx + zy * zy <= 4 && i < iterCount) {
+        const tmp = zx * zx - zy * zy + cx;
+        zy = 2 * zx * zy + cy;
+        zx = tmp;
+        i++;
+    }
+    return i;
+}
+
+function drawRandom() {
+    const canvas = document.getElementById('canvas');
+    const ctx = canvas.getContext('2d');
+    const width = canvas.width;
+    const height = canvas.height;
+    const imageData = ctx.createImageData(width, height);
+
+    for (let i = 0; i < imageData.data.length; i += 4) {
+        imageData.data[i] = Math.floor(Math.random() * 256);
+        imageData.data[i + 1] = Math.floor(Math.random() * 256);
+        imageData.data[i + 2] = Math.floor(Math.random() * 256);
+        imageData.data[i + 3] = 255;
+    }
+    ctx.putImageData(imageData, 0, 0);
+}
+
+function draw() {
+    const canvas = document.getElementById('canvas');
+    const ctx = canvas.getContext('2d');
+    const width = canvas.width;
+    const height = canvas.height;
+    const imageData = ctx.createImageData(width, height);
+
+    const mode = document.getElementById('mode').value;
+    if (mode === 'random') {
+        drawRandom();
+        return;
+    }
+
+    const type = document.getElementById('fractal-type').value;
+    const iterCount = parseInt(document.getElementById('iterations').value, 10);
+    const juliaC = parseComplex(document.getElementById('julia-c').value);
+
+    for (let y = 0; y < height; y++) {
+        for (let x = 0; x < width; x++) {
+            let zx = (x - width / 2) * 4 / width;
+            let zy = (y - height / 2) * 4 / width;
+            let cx = zx;
+            let cy = zy;
+            if (type === 'julia') {
+                cx = juliaC.re;
+                cy = juliaC.im;
+            }
+
+            const i = calculateIterations(zx, zy, cx, cy, iterCount);
+
+            const pixelIndex = (y * width + x) * 4;
+            const color = i === iterCount ? 0 : 255 - Math.floor(255 * i / iterCount);
+            imageData.data[pixelIndex] = color;
+            imageData.data[pixelIndex + 1] = color;
+            imageData.data[pixelIndex + 2] = color;
+            imageData.data[pixelIndex + 3] = 255;
+        }
+    }
+    ctx.putImageData(imageData, 0, 0);
+}
+
+if (typeof document !== 'undefined') {
+    document.getElementById('render').addEventListener('click', draw);
+    window.addEventListener('load', draw);
+}
+
+if (typeof module !== 'undefined') {
+    module.exports = { parseComplex, calculateIterations };
+}

--- a/script.js
+++ b/script.js
@@ -17,8 +17,8 @@ function calculateIterations(zx, zy, cx, cy, iterCount) {
     return i;
 }
 
-function drawRandom() {
-    const canvas = document.getElementById('canvas');
+function drawRandom(canvas = (typeof document !== 'undefined' ? document.getElementById('canvas') : null)) {
+    if (!canvas) return;
     const ctx = canvas.getContext('2d');
     const width = canvas.width;
     const height = canvas.height;
@@ -42,7 +42,7 @@ function draw() {
 
     const mode = document.getElementById('mode').value;
     if (mode === 'random') {
-        drawRandom();
+        drawRandom(canvas);
         return;
     }
 
@@ -80,5 +80,5 @@ if (typeof document !== 'undefined') {
 }
 
 if (typeof module !== 'undefined') {
-    module.exports = { parseComplex, calculateIterations };
+    module.exports = { parseComplex, calculateIterations, drawRandom };
 }

--- a/style.css
+++ b/style.css
@@ -1,0 +1,14 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #222;
+    color: #eee;
+    text-align: center;
+}
+
+#controls {
+    margin-bottom: 1em;
+}
+
+canvas {
+    border: 1px solid #555;
+}

--- a/test/random.test.js
+++ b/test/random.test.js
@@ -1,0 +1,29 @@
+const assert = require('assert');
+const { drawRandom } = require('../script');
+
+function createStubCanvas(width, height) {
+  const ctx = {
+    createImageData(w, h) {
+      return { data: new Uint8ClampedArray(w * h * 4) };
+    },
+    putImageData(img) {
+      this.imageData = img;
+    }
+  };
+  return {
+    width,
+    height,
+    getContext() {
+      return ctx;
+    },
+    ctx
+  };
+}
+
+const canvas = createStubCanvas(2, 2);
+drawRandom(canvas);
+assert(canvas.ctx.imageData, 'imageData should be set');
+const data = canvas.ctx.imageData.data;
+const allZero = data.every(v => v === 0);
+assert(!allZero, 'pixels should be randomized');
+console.log('Random draw test passed');

--- a/test/script.test.js
+++ b/test/script.test.js
@@ -1,0 +1,23 @@
+const assert = require('assert');
+const { parseComplex, calculateIterations } = require('../script');
+
+// Test parseComplex with valid input
+const c1 = parseComplex('-0.4+0.6i');
+assert.strictEqual(c1.re, -0.4);
+assert.strictEqual(c1.im, 0.6);
+
+// Test parseComplex with invalid input defaults
+const c2 = parseComplex('invalid');
+assert.strictEqual(c2.re, -0.8);
+assert.strictEqual(c2.im, 0.156);
+
+// Mandelbrot iteration test: points inside set should reach max iterations
+const iterCount = 50;
+let i = calculateIterations(0, 0, 0, 0, iterCount);
+assert.strictEqual(i, iterCount);
+
+// Point outside the set should escape early
+i = calculateIterations(2, 2, 2, 2, iterCount);
+assert(i < iterCount);
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- extend README usage section
- add mode selector to HTML
- implement random color image generation in JS

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684391be10288324971b7b6867016545