### PR TITLE
Add drawRandom test with canvas mock

### DIFF
--- a/script.js
+++ b/script.js
@@ -57,6 +57,23 @@ if (typeof document !== 'undefined') {
     window.addEventListener('load', draw);
 }
 
+function drawRandom(canvas) {
+    const ctx = canvas.getContext('2d');
+    const width = canvas.width;
+    const height = canvas.height;
+    const imageData = ctx.createImageData(width, height);
+
+    for (let i = 0; i < imageData.data.length; i += 4) {
+        const color = Math.floor(Math.random() * 256);
+        imageData.data[i] = color;
+        imageData.data[i + 1] = color;
+        imageData.data[i + 2] = color;
+        imageData.data[i + 3] = 255;
+    }
+    ctx.putImageData(imageData, 0, 0);
+    return imageData;
+}
+
 if (typeof module !== 'undefined') {
-    module.exports = { parseComplex, calculateIterations };
+    module.exports = { parseComplex, calculateIterations, drawRandom };
 }

--- a/test/script.test.js
+++ b/test/script.test.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const { parseComplex, calculateIterations } = require('../script');
+const { parseComplex, calculateIterations, drawRandom } = require('../script');
 
 // Test parseComplex with valid input
 const c1 = parseComplex('-0.4+0.6i');
@@ -19,5 +19,36 @@ assert.strictEqual(i, iterCount);
 // Point outside the set should escape early
 i = calculateIterations(2, 2, 2, 2, iterCount);
 assert(i < iterCount);
+
+// Fake canvas implementation for drawRandom test
+class FakeContext {
+    constructor(width, height) {
+        this.width = width;
+        this.height = height;
+        this.imageData = null;
+    }
+    createImageData(width, height) {
+        return { data: new Uint8ClampedArray(width * height * 4) };
+    }
+    putImageData(imageData) {
+        this.imageData = imageData;
+    }
+}
+
+class FakeCanvas {
+    constructor(width, height) {
+        this.width = width;
+        this.height = height;
+        this.ctx = new FakeContext(width, height);
+    }
+    getContext(type) {
+        return this.ctx;
+    }
+}
+
+const canvas = new FakeCanvas(2, 2);
+drawRandom(canvas);
+const pixelData = canvas.ctx.imageData.data;
+assert(Array.from(pixelData).some(v => v !== 0), 'drawRandom should populate pixel data');
 
 console.log('All tests passed');


### PR DESCRIPTION
## Summary
- export new `drawRandom` function from `script.js`
- add `drawRandom` tests using a fake canvas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a19959e908324907f5758e690d9a3